### PR TITLE
Supercollider example: Set maxLogins to allow more than one remote

### DIFF
--- a/examples/12-SuperCollider-EXPERIMENTAL/start-scsynth/_main.scd
+++ b/examples/12-SuperCollider-EXPERIMENTAL/start-scsynth/_main.scd
@@ -14,6 +14,7 @@ s = Server.default;
 s.options.numAnalogInChannels = 8;
 s.options.numAnalogOutChannels = 8;
 s.options.numDigitalChannels = 16;
+s.options.maxLogins = 64;  	   // set max number of clients
 
 s.options.pgaGainLeft = 4;     // sets the pga gain of the left channel to 4 dB
 s.options.pgaGainRight = 5;    // sets the pga gain of the right channel to 5 dB


### PR DESCRIPTION
ServerOptions sets maxLogins to 1 by default. This sets maxLogins to scsynth default (64) to allow remote connection from another computer.