### PR TITLE
Added styling to get rid of shadow dom arrows in moz and webkit

### DIFF
--- a/IDE/frontend-dev/design/styles/_dropdown-mini.scss
+++ b/IDE/frontend-dev/design/styles/_dropdown-mini.scss
@@ -1,12 +1,13 @@
 .mini-dropdown select {
-  border: transparent;
-  height: 25px;
-  width: 100%;
-  padding-left: 10px;
+  -moz-appearance: none;
+  -webkit-appearance: none;
   background: transparent;
+  border: transparent;
   font-family: poppins_light;
-  -webkit-appearance: button;
+  height: 25px;
+  padding-left: 10px;
   vertical-align: center;
+  width: 100%;
   option {
     width: 100%;
   }

--- a/IDE/frontend-dev/design/styles/_dropdown.scss
+++ b/IDE/frontend-dev/design/styles/_dropdown.scss
@@ -1,4 +1,5 @@
 /* Dropdown Button */
+
 button.dropbtn {
   background-color: #fff;
   border: 1px solid $teal-main;

--- a/IDE/public/css/style.css
+++ b/IDE/public/css/style.css
@@ -721,7 +721,7 @@ select.dropdown-num {
   padding-left: 10px;
   background: transparent;
   font-family: poppins_light;
-  -webkit-appearance: button;
+  -webkit-appearance: none;
   vertical-align: center; }
   .mini-dropdown select option {
     width: 100%; }
@@ -1996,7 +1996,7 @@ input[type="range"].scope-range-slider {
     width: 12px; }
   input[type="range"].scope-range-slider:hover::-moz-range-track, input[type="range"].scope-range-slider:active::-moz-range-track {
     background: #1ce8b5;
-    -webkit-transition: background, 100ms, ease-in-out;
+    -moz-transition: background, 100ms, ease-in-out;
     transition: background, 100ms, ease-in-out; }
   input[type="range"].scope-range-slider:hover::-webkit-slider-runnable-track, input[type="range"].scope-range-slider:active::-webkit-slider-runnable-track {
     background: #1ce8b5;

--- a/IDE/public/css/style.css
+++ b/IDE/public/css/style.css
@@ -715,14 +715,15 @@ select.dropdown-num {
     display: block; }
 
 .mini-dropdown select {
-  border: transparent;
-  height: 25px;
-  width: 100%;
-  padding-left: 10px;
-  background: transparent;
-  font-family: poppins_light;
+  -moz-appearance: none;
   -webkit-appearance: none;
-  vertical-align: center; }
+  background: transparent;
+  border: transparent;
+  font-family: poppins_light;
+  height: 25px;
+  padding-left: 10px;
+  vertical-align: center;
+  width: 100%; }
   .mini-dropdown select option {
     width: 100%; }
   .mini-dropdown select .git {


### PR DESCRIPTION
Quick fix to address shadow dom arrows appearing on styled dropdowns