### PR TITLE
FIX: Popup Long Title Fix - …

### DIFF
--- a/IDE/frontend-dev/design/styles/_popup.scss
+++ b/IDE/frontend-dev/design/styles/_popup.scss
@@ -41,6 +41,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     width: 100%;
+    white-space: nowrap;
     &.error {
       color: $accent-red;
     }

--- a/IDE/frontend-dev/design/styles/_popup.scss
+++ b/IDE/frontend-dev/design/styles/_popup.scss
@@ -38,6 +38,9 @@
     color: $teal-main;
     font-size: 2em;
     font-family: space_bold;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
     &.error {
       color: $accent-red;
     }

--- a/IDE/public/css/style.css
+++ b/IDE/public/css/style.css
@@ -1163,7 +1163,11 @@ ul dl {
   #popup h1 {
     color: #00bea4;
     font-size: 2em;
-    font-family: space_bold; }
+    font-family: space_bold;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
+    white-space: nowrap; }
     #popup h1.error {
       color: #ff5e5b; }
   #popup h3 {


### PR DESCRIPTION
A suggested fix which changes 'Delete filenamewhichisreallylongand obviouslywontfitontoamodalwindow' to 'Delete filenamewhich…'

![Screenshot 2020-02-03 at 21 18 56](https://user-images.githubusercontent.com/879536/73687648-cfb05780-46ca-11ea-93ac-a6b5b9951946.png)
