### PR TITLE
Build script tweaks

### DIFF
--- a/scripts/.bela_common
+++ b/scripts/.bela_common
@@ -47,6 +47,20 @@ check_rsync(){
 	fi
 }
 
+check_if_sources_copied(){
+	input=$(</dev/stdin)
+	[ -n "$input" ] && echo "$input" # rsync output is printed normally
+
+	source_exist=0
+	while read i; do
+		ext=$(echo "$i" | sed 's/.*\.//')
+		if [ "$ext" = "c" ] || [ "$ext" = "cpp" ] || [ "$ext" = "S" ] || [ "$ext" = "pd" ] || [ "$ext" = "scd" ]; then source_exist=1; fi
+	done <<< "$input"
+
+	[ $source_exist -eq "0" ] && echo "Warning: no new source files were copied to the board" # possibly could be handled automatically (ex. deleting associated .o files if they exist)
+	return 0
+}
+
 folder_has_changed(){
 	[ -z "$2" ] && { echo "Error: folder_has_changed(folder, reference, [filter])"; return 1; }
 	[ -z "$3" ] && FILTER="." || FILTER="$3"

--- a/scripts/.bela_common
+++ b/scripts/.bela_common
@@ -48,16 +48,13 @@ check_rsync(){
 }
 
 check_if_sources_copied(){
-	input=$(</dev/stdin)
-	[ -n "$input" ] && echo "$input" # rsync output is printed normally
-
-	source_exist=0
-	while read i; do
-		ext=$(echo "$i" | sed 's/.*\.//')
-		if [ "$ext" = "c" ] || [ "$ext" = "cpp" ] || [ "$ext" = "S" ] || [ "$ext" = "pd" ] || [ "$ext" = "scd" ]; then source_exist=1; fi
-	done <<< "$input"
-
-	[ $source_exist -eq "0" ] && echo "Warning: no new source files were copied to the board" # possibly could be handled automatically (ex. deleting associated .o files if they exist)
+	RSYNC_OUTPUT=$(</dev/stdin)
+	# rsync output is printed normally
+	[ -n "$RSYNC_OUTPUT" ] && echo "$RSYNC_OUTPUT"
+	EXTENSION_LIST='\.cpp\|\.c\|\.S\|\.pd\|\.scd'
+	FOUND_EXTENSIONS=$(echo "$RSYNC_OUTPUT" | grep "$EXTENSION_LIST")
+	# possibly could be handled automatically (ex. deleting associated .o files if they exist)
+	[ -z "$FOUND_EXTENSIONS" ] && echo "Warning: no new source files were copied to the board"
 	return 0
 }
 

--- a/scripts/build_project.sh
+++ b/scripts/build_project.sh
@@ -158,7 +158,7 @@ uploadBuildRun(){
 		# --no-t makes sure file timestamps are not preserved, so that the Makefile will not think that targets are up to date when replacing files on the BBB
 		#  with older files from the host. This will solve 99% of the issues with Makefile thinking a target is up to date when it is not.
 		echo "using rsync..."
-		rsync -ac --out-format="   %n" --no-t --delete-after --exclude=$BBB_PROJECT_NAME --exclude=build $HOST_SOURCE_PATH"/" "$BBB_NETWORK_TARGET_FOLDER/" | tee | checkIfOnlyHeaders #trailing slashes used here make sure rsync does not create another folder inside the target folder
+		rsync -ac --out-format="   %n" --no-t --delete-after --exclude=$BBB_PROJECT_NAME --exclude=build $HOST_SOURCE_PATH"/" "$BBB_NETWORK_TARGET_FOLDER/" | check_if_sources_copied #trailing slashes used here make sure rsync does not create another folder inside the target folder
 	fi
 
 	if [ $? -ne 0 ]
@@ -176,24 +176,6 @@ uploadBuildRun(){
         echo "Building and running project..."
 	    case_run_mode
 	fi
-}
-
-# checks if the files copied to the board are only header files, prints a warning if so
-checkIfOnlyHeaders() {
-    input=$(</dev/stdin)
-    echo "$input"
-    source_exist=0
-
-    while read i; do
-        ext=$(echo "$i" | sed 's/.*\.//')
-        if [ $ext != "hpp" ] && [ $ext != "hh" ] && [ $ext != "h" ]; then
-            source_exist=1
-        fi
-    done <<< "$input"
-
-    if [ $source_exist -eq "0" ]; then
-        echo "WARNING: only header files were copied to the board - you may want to clean the project before building" # or whatever. possibly rm the associated .o file on the BBB?
-    fi
 }
 
 # run it once (or just touch the time_file)  and then (in case) start waiting for changes

--- a/scripts/set_startup.sh
+++ b/scripts/set_startup.sh
@@ -30,7 +30,8 @@ Options:
 	     case it crashes (default)
 	-s : runs the program in single-shot mode.
 	-c : passes command-line arguments to the Bela program. Make sure
-	     you enclose the argument string in quotes."
+	     you enclose the argument string in quotes.
+	-m : passes arguments to the Makefile before the run target."
 }
 
 ENABLE_STARTUP=1
@@ -40,6 +41,10 @@ do
 		-c)
 			shift;
 			COMMAND_ARGS="$1";
+		;;
+		-m)
+			shift;
+			BBB_MAKEFILE_OPTIONS="$BBB_MAKEFILE_OPTIONS $1";
 		;;
 		-l)
 			RUN_IN_LOOP=1
@@ -80,7 +85,7 @@ check_project_exists $BBB_PROJECT_NAME || {
 	list_available_projects
 	exit 1
 }
-MAKE_COMMAND="make --no-print-directory -C $BBB_BELA_HOME PROJECT=$BBB_PROJECT_NAME CL=\"$COMMAND_ARGS\""
+MAKE_COMMAND="make --no-print-directory -C $BBB_BELA_HOME PROJECT=$BBB_PROJECT_NAME CL=\"$COMMAND_ARGS\" $BBB_MAKEFILE_OPTIONS"
 if [ $ENABLE_STARTUP -eq 0 ]
 then
     ssh $BBB_ADDRESS "$MAKE_COMMAND nostartup"


### PR DESCRIPTION
Added two small QoL tweaks to the build scripts.

in `set_startup.sh`:

- added `-m` command line argument to allow extra makefile arguments to be passed to the script, similar to `build_project.sh`

in `build_project.sh`:

- added `check_if_sources_copied()`, which receives the output of the `rsync` command used to copy new files to the board
- this function checks if the new files copied are valid source files - specifically, if they have the extension `.c`, `.cpp`, `.S`, `.pd` or `.scd`
- if no valid source files are copied, a warning is printed to stdout

note that `check_if_sources_copied()` is not used if `rsync` is not available, since `scp` doesn't output to stdout unless it's in verbose mode - but since the project is recopied in its entirety every time, `build_project.sh` should catch that anyways