### PR TITLE
Fix OscSender Task name

### DIFF
--- a/libraries/OscSender/OscSender.cpp
+++ b/libraries/OscSender/OscSender.cpp
@@ -29,7 +29,7 @@ void OscSender::setup(int port, std::string ip_address){
 	socket->setup(port, ip_address.c_str());
 	
 	send_task = std::unique_ptr<AuxTaskNonRT>(new AuxTaskNonRT());
-	send_task->create(std::string("OscSenderTask_") + std::to_string(port), [this](void* buf, int size){send_task_func(buf, size); });
+	send_task->create(std::string("OscSenderTask_") + ip_address + std::to_string(port), [this](void* buf, int size){send_task_func(buf, size); });
 }
 
 OscSender &OscSender::newMessage(std::string address){


### PR DESCRIPTION
Fixes a problem with the way the task is named in OscSender which made it impossible to create two OscSenders to send to two different IP's on the same port.