### PR TITLE
Compiler-compatible zero-ing of 4x1 float vector

### DIFF
--- a/libraries/Biquad/Biquad.cpp
+++ b/libraries/Biquad/Biquad.cpp
@@ -124,8 +124,8 @@ int QuadBiquad::setup(const BiquadCoeff::Settings& settings)
 	for(auto & b : filters)
 		ret |= b.setup(settings);
 	update();
-	z1 = {0};
-	z2 = {0};
+	z1 = vmovq_n_f32(0);
+	z2 = vmovq_n_f32(0);
 	return ret;
 }
 void QuadBiquad::update()


### PR DESCRIPTION
This error was something the gcc compiler stumbled upon, while I was trying to cross-compile the Bela code.