### PR TITLE
fix format for binary mode echo

### DIFF
--- a/examples/Communication/logging-sensors/render.cpp
+++ b/examples/Communication/logging-sensors/render.cpp
@@ -85,7 +85,7 @@ bool setup(BelaContext *context, void *userData)
 	// set the format that you want to use for your output.
 	// Please use %f only (with modifiers).
 	// When in binary mode, this is used only for echoing to console
-	file1.setFormat("binary: %.4f %.4f\n");
+	file1.setFormat("binary: %.4f %.4f %.4f %.4f\n");
 
 	file2.setup("out.m"); //set the file name to write to
 	file2.setHeader("myvar=[\n"); //set one or more lines to be printed at the beginning of the file


### PR DESCRIPTION
The number of tokens in `file1.setFormat()` determines the logging buffer length. In [line 106](https://github.com/pelinski/Bela/blob/master/examples/Communication/logging-sensors/render.cpp#L106), there are four analog values logged to file 1, so the buffer length should be 4, and consequently, the number of tokens in `setFormat` should be 4 too. 