### PR TITLE
set BBB_NETWORK_TARGET_FOLDER after check_board_alive_and_set_date

### DIFF
--- a/scripts/build_project.sh
+++ b/scripts/build_project.sh
@@ -119,10 +119,11 @@ fi
 [ -z $BBB_PROJECT_NAME ] && BBB_PROJECT_NAME="$(basename $(cd "$HOST_SOURCE_PATH" && pwd))"
 
 BBB_PROJECT_FOLDER=$BBB_PROJECT_HOME"/"$BBB_PROJECT_NAME #make sure there is no trailing slash here
-BBB_NETWORK_TARGET_FOLDER=$BBB_ADDRESS:$BBB_PROJECT_FOLDER
 
 # The expert will have to remember to run set_date after powering up the board if needed
 [ "$BELA_EXPERT_MODE" -eq 0 ] && check_board_alive_and_set_date
+
+BBB_NETWORK_TARGET_FOLDER=$BBB_ADDRESS:$BBB_PROJECT_FOLDER
 
 # stop running process
 echo "Stop running process..."


### PR DESCRIPTION
I noticed that rsync failed and realized that it was because my board was showing up at 192.168.6.2 instead of the default BBB_ADDRESS.

check_board_alive_and_set_date updates BBB_ADDRESS to the correct address, but because BBB_NETWORK_TARGET_FOLDER was being set before running this check, it would use the default BBB_ADDRESS.

We need to set the network target folder *after* running this check, or the default BBB_ADDRESS gets copied into the target folder, and the change when checking that the board is alive does not propagate. This causes rsync in uploadBuildRun to fail.