### PR TITLE
poolsz should be size_t

### DIFF
--- a/include/xenomai_wraps.h
+++ b/include/xenomai_wraps.h
@@ -176,7 +176,7 @@ inline int create_and_start_thread(pthread_t* task, const char* taskName, int pr
 	return 0;
 }
 // from xenomai-3/demo/posix/cobalt/xddp-echo.c
-inline int createXenomaiPipe(const char* portName, int poolsz)
+inline int createXenomaiPipe(const char* portName, size_t poolsz)
 {
 	/*
 	 * Get a datagram socket to bind to the RT endpoint. Each

--- a/libraries/Pipe/Pipe.h
+++ b/libraries/Pipe/Pipe.h
@@ -84,7 +84,7 @@ private:
 	std::string path;
 	int pipeSocket;
 	int fd = 0;
-	int pipeSize;
+	size_t pipeSize;
 	double timeoutMsRt = 0;
 	double timeoutMsNonRt = 0;
 	bool blockingRt = false;


### PR DESCRIPTION
Creating the XDDP pipe with an int poolsz crashes on some systems - i.e. Cortex-A 64 bit.

When using size_t everything works fine, and it is also the type used in the xddp-echo examples: https://xenomai.org/documentation/xenomai-3/html/xeno3prm/xddp-echo_8c-example.html