### PR TITLE
Switchable Dark Theme - Attempt 2  - Ongoing

### DIFF
--- a/IDE/dist/IDESettings.js
+++ b/IDE/dist/IDESettings.js
@@ -168,6 +168,7 @@ function default_IDE_settings() {
         'cpuMonitoring': 1,
         'cpuMonitoringVerbose': 0,
         'consoleDelete': 0,
-        'viewHiddenFiles': 0
+        'viewHiddenFiles': 0,
+        'darkTheme': 0
     };
 }

--- a/IDE/frontend-dev/scss/_accordion-menu.scss
+++ b/IDE/frontend-dev/scss/_accordion-menu.scss
@@ -1,8 +1,50 @@
+// color-themed accordion menu elements
+@include themify($themes) {
+  button.accordion {
+    background-color: themed('accordion-background-color');
+    border-bottom: 2px solid themed('main-background-color');
+    color: themed('accordion-font-color');
+
+    &:hover {
+      background: themed('hovered-accordion-color');
+    }
+
+    &.active {
+      background-color: themed('accordion-background-color');
+      color: themed('accordion-font-color-accent');
+
+      &:hover {
+        color: themed('accordion-font-color-accent');
+      }
+    }
+    &:after {
+      color: themed('accordion-font-color');
+    }
+  }
+  button.accordion-sub {
+    border-bottom: 1px solid themed('tabs-color');
+    color: themed('accordion-font-color-accent');
+    &:hover {
+      color: themed('accordion-font-color-accent');
+    }
+    &.active {
+      color: themed('accordion-font-color-accent');
+      &:hover {
+        color: themed('accordion-font-color-accent');
+      }
+    }
+  }
+  .docs-content {
+    color: themed('main-font-color');
+  }
+  .panel.show {
+    color: themed('main-font-color');
+  }
+}
+
+
 button.accordion {
-  background-color: $grey-light;
   border: none;
-  border-bottom: 2px solid #fff;
-  color: rgba(0, 0, 0, 0.6);
   cursor: pointer;
   font-family: poppins_regular;
   font-size: 16px;
@@ -13,23 +55,16 @@ button.accordion {
   transition: 0.25s ease-in-out;
   width: 100%;
   &:hover {
-    background: $grey-mid;
     border-bottom: 2px solid $teal-main;
   }
   &.active {
-    background-color: $grey-light;
     border-bottom: 2px solid $teal-main;
-    color: $grey-dark;
     padding: 8px 14px;
-    &:hover {
-      color: $grey-dark;
-    }
     &:after {
       content: "\2796"; /* Unicode character for "minus" sign (-) */
     }
   }
   &:after {
-    color: rgba(0, 0, 0, 0.6);
     content: '\02795'; /* Unicode character for "plus" sign (+) */
     float: right;
     font-size: 14px;
@@ -39,12 +74,10 @@ button.accordion {
 
 button.accordion-sub {
   background: transparent;
-  border-bottom: 1px solid $grey-toolbar;
   border-top: 0;
   border-left: 0;
   border-right: 0;
   border-radius: 0;
-  color: $grey-dark;
   font-size: 1em;
   font-family: 'poppins_regular';
   padding: .4em .8em .25em;
@@ -52,17 +85,12 @@ button.accordion-sub {
   width: 100%;
   &:hover {
     background: rgba($grey-toolbar,0.2);
-    color: $grey-dark;
   }
   &.active {
     background: transparent;
     border-bottom: 2px solid $teal-01;
-    color: $grey-dark;
     padding-bottom: .2em;
     margin-top: .2em;
-    &:hover {
-      color: $grey-dark;
-    }
     &:after {
       content: "\2796"; /* Unicode character for "minus" sign (-) */
       font-size: .75em;

--- a/IDE/frontend-dev/scss/_buttons.scss
+++ b/IDE/frontend-dev/scss/_buttons.scss
@@ -1,3 +1,17 @@
+// color-themed button elements
+@include themify($themes) {
+  button,
+  .button {
+    background-color: themed('main-background-color');
+    color: themed('main-font-color');
+    &.create-project {
+      &:before {
+      color: themed('accordion-font-color-accent');
+      }
+    }
+  }
+}
+
 a.button {
   color: black;
   font-size: 11px;
@@ -10,9 +24,7 @@ a.button {
 button,
 .button {
   border: 1px solid $teal-main;
-  background-color: $white;
   border-radius: 3px;
-  color: $black;
   font-size: .8em;
   cursor: pointer;
   font-family: poppins_light;
@@ -36,7 +48,6 @@ button,
       color: $white;
     }
     &:before {
-      color: $grey-dark;
       content: '+'; /* Unicode character for "plus" sign (+) */
       font-family: space_bold;
       font-size: 36px;

--- a/IDE/frontend-dev/scss/_console.scss
+++ b/IDE/frontend-dev/scss/_console.scss
@@ -1,5 +1,12 @@
+// color-themed console elements
+@include themify($themes) {
+  #beaglert-console {
+    background-color: themed('main-background-color');
+    color: themed('main-font-color');
+  }
+}
+
 #beaglert-console {
-  background-color: white;
   box-sizing: border-box;
   font-family: inconsolata, monospace;
   font-size: 12px;

--- a/IDE/frontend-dev/scss/_dropdown-mini.scss
+++ b/IDE/frontend-dev/scss/_dropdown-mini.scss
@@ -1,3 +1,10 @@
+// color-themed sub-accordion elements
+@include themify($themes) {
+  .mini-dropdown select{
+    color: themed('accordion-font-color');
+  }
+}
+
 .mini-dropdown select {
   -moz-appearance: none;
   -webkit-appearance: none;

--- a/IDE/frontend-dev/scss/_dropdown.scss
+++ b/IDE/frontend-dev/scss/_dropdown.scss
@@ -1,7 +1,29 @@
-/* Dropdown Button */
+// color-themed dropdown button elements
+@include themify($themes) {
+  button.dropbtn {
+    background-color: themed('selected-tab-color');
+  }
+  .dropdown-content {
+    background-color: themed('hovered-accordion-color-two');
+    select {
+      option {
+        color: themed('main-font-color');
+      }
+    }
+    ul {
+      > li, span, a {
+        color: themed('main-font-color');
+        &:hover {
+          background-color: themed('cursor-color');
+          color: themed('main-font-color-accent');
+        }
+      }
+    }
+  }
+}
 
+/* Dropdown Button */
 button.dropbtn {
-  background-color: #fff;
   border: 1px solid $teal-main;
   color: $teal-main;
   cursor: pointer;
@@ -75,7 +97,6 @@ select.dropdown-num {
 
 /* Dropdown content (hidden by default) */
 .dropdown-content {
-  background-color: #f9f9f9;
   box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
   display: none;
   min-width: 160px;
@@ -92,7 +113,6 @@ select.dropdown-num {
     padding-top: 0;
     width: 200px;
     option {
-      color: black;
       cursor: pointer;
       display: block;
       font-family: poppins_regular;
@@ -123,7 +143,6 @@ select.dropdown-num {
       user-select: none;
     }
     > li, span, a {
-      color: black;
       cursor: pointer;
       display: block;
       font-family: poppins_regular;
@@ -131,10 +150,6 @@ select.dropdown-num {
       opacity: 1;
       padding: 8px 16px;
       text-decoration: none;
-      &:hover {
-        background-color: $grey-light;
-        color: rgba(0, 0, 0, 0.9);
-      }
     }
   }
   &.show {

--- a/IDE/frontend-dev/scss/_editor.scss
+++ b/IDE/frontend-dev/scss/_editor.scss
@@ -1,5 +1,9 @@
+// color-themed editor elements
+@include themify($themes) {
+  background: themed('main-background-color');
+}
+
 #editor {
-  background: #fff;
   display: none;
   float: left;
   height: calc(100% - 70px);

--- a/IDE/frontend-dev/scss/_library-list.scss
+++ b/IDE/frontend-dev/scss/_library-list.scss
@@ -1,3 +1,14 @@
+// color-themed library list elements
+@include themify($themes) {
+  ul {
+    .libraries-list {
+      li {
+        color: themed('accordion-font-color-accent');
+      }
+    }
+  }
+}
+
 ul {
   &.libraries-list-parent {
     list-style: none;
@@ -68,7 +79,6 @@ ul {
     }
     .libraries-list {
       li {
-        color: rgba(0, 0, 0, 0.8);
         cursor: pointer;
         font-family: inconsolata;
       	font-size: 14px;

--- a/IDE/frontend-dev/scss/_popup.scss
+++ b/IDE/frontend-dev/scss/_popup.scss
@@ -1,3 +1,15 @@
+// color-themed popup elements
+@include themify($themes) {
+  #popup {
+    background: themed('selected-tab-color');
+  }
+  button {
+    &.cancel {
+      background: themed('selected-tab-color');
+    }
+  }
+}
+
 #popup-nointeraction {
   display: none;
   height: 100vh;
@@ -134,7 +146,6 @@
       }
     }
     &.cancel {
-      background: $white;
       border: 1px solid $grey-mid;
       &:hover {
         background: $grey-light-mid;

--- a/IDE/frontend-dev/scss/_tab-content.scss
+++ b/IDE/frontend-dev/scss/_tab-content.scss
@@ -1,5 +1,29 @@
+// color-themed tab elements
+@include themify($themes) {
+  .choice {
+    color: themed('accordion-font-color');
+  }
+  p.project {
+    color: themed('main-font-color')
+  }
+  .project-actions {
+    >.project-text {
+      color: themed('accordion-font-color-accent');
+    }
+  }
+  input[type="checkbox"].checkbox-slider,
+  .checkbox-slider input[type="checkbox"] {
+    &::before {
+      background: themed('checkbox-slider-color');
+    }
+  }
+  textarea {
+    background-color: themed('text-area-color');
+    color: themed('main-font-color');
+  }
+}
+
 .choice {
-  color: rgba(0, 0, 0, 0.6);
   font-family: poppins_light;
   font-size: 12px;
   padding-bottom: 10px;
@@ -82,7 +106,6 @@ input[type="checkbox"].checkbox-slider,
   }
 
   &::before {
-    background: #ccc;
     border-radius: 18px;
     height: 18px;
     transition: background-color 200ms;
@@ -161,7 +184,6 @@ p.project {
   >.project-text {
     display: inline;
     font-family: 'inconsolata';
-    color: $grey-dark;
     font-size: .85em;
     position: absolute;
     top: 0;

--- a/IDE/frontend-dev/scss/_tab-menu.scss
+++ b/IDE/frontend-dev/scss/_tab-menu.scss
@@ -1,15 +1,60 @@
+// color-themed tab menu elements
+@include themify($themes) {
+  #tab-menu {
+    li#open-tab {
+      background-color: themed('tabs-color');
+    }
+    li {
+      background: themed('tabs-color');
+      &.explorer {
+        &.active{
+          background: themed('selected-tab-color') url('../images/icons/folder_active.svg') no-repeat center;
+        }
+      }
+      &.examples {
+        &.active {
+          background: themed('selected-tab-color') url('../images/icons/examples_active.svg') no-repeat center;
+        }
+      }
+      &.settings {
+        &.active {
+          background: themed('selected-tab-color') url('../images/icons/settings_active.svg') no-repeat center;
+        }
+      }
+      &.pins {
+        &.active {
+          background: themed('selected-tab-color') url('../images/icons/pins_active.svg') no-repeat center;
+        }
+      }
+      &.refs {
+        &.active {
+          background: themed('selected-tab-color') url('../images/icons/refs_active.svg') no-repeat center;
+        }
+      }
+      &.libraries {
+        &.active {
+          background: themed('selected-tab-color') url('../images/icons/library_green.svg') no-repeat center;
+        }
+      }
+      &.feedback {
+        &.active {
+          background: themed('selected-tab-color') url('../images/icons/feedback_active.svg') no-repeat center;
+        }
+      }
+    }
+  }
+}
+
 /*
  * Make each label stack on top of one another.
  *
  */
 #tab-menu {
   li#open-tab {
-    background-color: $grey-tabs;
     max-width: 40px;
     padding-left: 10px;
   }
   li {
-    background: $grey-tabs;
     cursor: pointer;
     height: 50px;
     padding: 0;
@@ -31,17 +76,11 @@
       &:hover {
         background: url('../images/icons/folder_active.svg') no-repeat center;
       }
-      &.active{
-        background: $white url('../images/icons/folder_active.svg') no-repeat center;
-      }
     }
     &.examples {
       background: url('../images/icons/examples_inactive.svg') no-repeat center;
         &:hover {
           background: url('../images/icons/examples_active.svg') no-repeat center;
-        }
-        &.active {
-          background: $white url('../images/icons/examples_active.svg') no-repeat center;
         }
       }
       &.settings {
@@ -49,17 +88,11 @@
       &:hover {
         background: url('../images/icons/settings_active.svg') no-repeat center;
       }
-      &.active {
-        background: $white url('../images/icons/settings_active.svg') no-repeat center;
-      }
     }
     &.pins {
         background: url('../images/icons/pins_inactive.svg') no-repeat center;
       &:hover {
         background: url('../images/icons/pins_active.svg') no-repeat center;
-      }
-      &.active {
-        background: $white url('../images/icons/pins_active.svg') no-repeat center;
       }
     }
     &.refs {
@@ -67,17 +100,11 @@
       &:hover {
         background: url('../images/icons/refs_active.svg') no-repeat center;
       }
-      &.active {
-        background: $white url('../images/icons/refs_active.svg') no-repeat center;
-      }
     }
     &.libraries {
       background: url('../images/icons/library_white.svg') no-repeat center;
       &:hover {
         background: url('../images/icons/library_green.svg') no-repeat center;
-      }
-      &.active {
-        background: $white url('../images/icons/library_green.svg') no-repeat center;
       }
     }
     &.feedback {
@@ -86,7 +113,6 @@
         background: url('../images/icons/feedback_active.svg') no-repeat center;
       }
       &.active {
-        background: $white url('../images/icons/feedback_active.svg') no-repeat center;
         border-left: 5px solid $accent-red;
       }
     }

--- a/IDE/frontend-dev/scss/_tabs.scss
+++ b/IDE/frontend-dev/scss/_tabs.scss
@@ -1,8 +1,28 @@
+// color-themed tabs elements
+@include themify($themes) {
+  //.tabs {
+	//background-color: themed('tabs-color');
+  //}
+  #tab-menu {
+    background-color: themed('tabs-color');
+  }
+  #tab-content-area {
+    background-color: themed('main-background-color');
+  }
+  section#tab-content {
+    .title-container {
+      background-color: themed('main-background-color');
+      h1 {
+        color: themed('accordion-font-color-accent');
+      }
+    }
+  }
+}
+
 $tab-width: 450px;
 
 /* Tabbed content */
 .tabs {
-	background-color: white;
 	height: calc(100% + 35px);
   left: calc(100% - 50px);
   position: absolute;
@@ -23,14 +43,12 @@ $tab-width: 450px;
 }
 
 #tab-menu {
-  background-color: $grey-tabs;
   float: left;
   height: 100%;
   width: 50px;
 }
 
 #tab-content-area {
-  background-color: #fff;
   height: calc(100% - 76px);
   overflow: auto;
 }
@@ -43,7 +61,6 @@ section#tab-content {
     display: none;
   }
   .title-container {
-    background-color: $white;
     height: 75px;
     position: sticky;
     position: -webkit-sticky; /* Required for Safari */
@@ -56,7 +73,6 @@ section#tab-content {
     }
     h1 {
       border-bottom: 10px solid $teal-01;
-      color: rgba(0, 0, 0, 0.8);
       display: inline-block;
       font-family: space_bold;
       font-size: 24px;

--- a/IDE/frontend-dev/scss/_text-input.scss
+++ b/IDE/frontend-dev/scss/_text-input.scss
@@ -1,9 +1,17 @@
+// color-themed text input elements
+@include themify($themes) {
+	input[type="text"],
+	input[type="number"] {
+		background: themed('main-background-color');
+		color: themed('main-font-color-accent');
+	}
+}
+
 // INPUTS
 input[type="text"],
 input[type="number"] {
 	height: 25px;
 	border: 1px solid $grey-mid;
-	background: $white;
 	&.number-picker {
 		border-radius: 0;
 		width: 5em;

--- a/IDE/frontend-dev/scss/_toolbar.scss
+++ b/IDE/frontend-dev/scss/_toolbar.scss
@@ -1,3 +1,16 @@
+// color-themed toolbar elements
+@include themify($themes) {
+  .toolbar {
+    background: themed('tabs-color');
+    .tool-text {
+      color: themed('main-font-color');
+    }
+    .system-status-text {
+      color: themed('main-font-color') !important;
+    }
+  }
+}
+
 @keyframes running-button {
   from {
     transform: rotate(0deg);
@@ -17,7 +30,6 @@
 
 
 .toolbar {
-  background: $grey-toolbar;
   bottom: 0;
   box-shadow: 5px 5px #eee;
   display: block;

--- a/IDE/frontend-dev/scss/_upper.scss
+++ b/IDE/frontend-dev/scss/_upper.scss
@@ -1,3 +1,13 @@
+// color-themed top bar elements
+@include themify($themes) {
+  .file-status {
+    .current {
+      color: themed('accordion-font-color');
+      background-color: themed('top-file-status-color');
+    }
+  }
+}
+
 .file-status {
   margin-left: 60px;
   white-space: nowrap;
@@ -30,7 +40,6 @@
   }
   .current {
     font-family: poppins_regular;
-    color: rgba(0, 0, 0, 0.7);
     padding-right: 20px;
     font-size: 12px;
   }

--- a/IDE/frontend-dev/scss/base.scss
+++ b/IDE/frontend-dev/scss/base.scss
@@ -5,7 +5,7 @@ $black: #000;
 $white: #ffffff;
 
 // Base Material palette teal:
-$teal-base: #009587;
+$teal-base: #950000;
 
 // Main Bela color:
 $teal-main: #00bea4; //rgb(0,190,164)
@@ -38,6 +38,59 @@ $trans-reg: 0.1s;
 $yellow-accent: #fff07c;
 $yellow-accent-fade: #FFFFC9;
 
+$themes: (
+  light: (
+    main-background-color: $white,
+    tabs-color: $grey-toolbar,
+    selected-tab-color: $white,
+    top-file-status-color: #e1e1e1,
+    accordion-background-color: $grey-light,
+    hovered-accordion-color: $grey-mid,
+    accordion-font-color: rgba(0, 0, 0, 0.6),
+    accordion-font-color-accent: $grey-dark,
+    main-font-color: $black,
+    hovered-accordion-color-two: #f9f9f9,
+    main-font-color-accent: $black,
+    cursor-color: $grey-light,
+    console-dragger-color: #999,
+    console-dragger-opacity: 0.001,
+    console-dragged-color: #bbb,
+    checkbox-slider-color: #ccc,
+    text-area-color: $white,
+  ),
+  dark: (
+    main-background-color: #292a2f,
+    tabs-color: #252729,
+    selected-tab-color: #252729,
+    top-file-status-color: #252729,
+    accordion-background-color: #3f4045,
+    hovered-accordion-color: #3e4d5c,
+    accordion-font-color: #dfdfe0,
+    accordion-font-color-accent: #ededf2,
+    main-font-color: #dfdfe0,
+    hovered-accordion-color-two: #3f4045,
+    main-font-color-accent: #ededf2,
+    cursor-color: rgb(44,44,44),
+    console-dragger-color: #3f4045,
+    console-dragger-opacity: 1,
+    console-dragged-color: #5a5a62,
+    checkbox-slider-color: #5a5a62,
+    text-area-color: #292a2f,
+  )
+);
+
+@mixin themify($themes) {
+  @each $name, $values in $themes {
+    .#{$name}-theme {
+      $theme-map: $values !global;
+      @content;
+    }
+  }
+}
+@function themed($key) {
+  @return map-get($theme-map, $key);
+}
+
 @import 'reset';
 @import 'fonts';
 
@@ -61,9 +114,28 @@ img {
   display: none;
 }
 
+// color-themed top bar elements
+@include themify($themes) {
+  .upper {
+    background-color: themed('top-file-status-color');
+  }
+  .lm_content {
+    border: 1px solid themed('tabs-color');
+  }
+  .lm_splitter {
+    background-color: themed('console-dragger-color') !important;
+    opacity: themed('console-dragger-opacity');
+    &:hover {
+      background-color: themed('console-dragged-color') !important;
+    }
+  }
+
+
+}
+
 .upper {
-	height: 100%;
-	position: relative;
+  height: 100%;
+  position: relative;
   z-index: 96;
 }
 

--- a/IDE/frontend-dev/src/Views/EditorView.js
+++ b/IDE/frontend-dev/src/Views/EditorView.js
@@ -338,6 +338,20 @@ class EditorView extends View {
 		currentFile = name;
 	}
 
+	// switch between light and dark theme
+	_darkTheme(isDarkTheme){
+		var body = $('body');
+		if (isDarkTheme) {
+			this.editor.setTheme("ace/theme/xcode_dark");
+			body.toggleClass('light-theme', Boolean(false));
+			body.toggleClass('dark-theme', Boolean(true));
+		} else {
+			this.editor.setTheme("ace/theme/chrome");
+			body.toggleClass('dark-theme', Boolean(false));
+			body.toggleClass('light-theme', Boolean(true));
+		}
+	}
+
 	getCurrentWord(){
 		var pos = this.editor.getCursorPosition();
 		//var range = this.editor.session.getAWordRange(pos.row, pos.column);

--- a/IDE/public/css/style.css
+++ b/IDE/public/css/style.css
@@ -80,6 +80,30 @@ img {
 .hidden {
   display: none; }
 
+.light-theme .upper {
+  background-color: #e1e1e1; }
+
+.light-theme .lm_content {
+  border: 1px solid #c9c9c9; }
+
+.light-theme .lm_splitter {
+  background-color: #999 !important;
+  opacity: 0.001; }
+  .light-theme .lm_splitter:hover {
+    background-color: #bbb !important; }
+
+.dark-theme .upper {
+  background-color: #252729; }
+
+.dark-theme .lm_content {
+  border: 1px solid #252729; }
+
+.dark-theme .lm_splitter {
+  background-color: #3f4045 !important;
+  opacity: 1; }
+  .dark-theme .lm_splitter:hover {
+    background-color: #5a5a62 !important; }
+
 .upper {
   height: 100%;
   position: relative;
@@ -143,11 +167,68 @@ body.uploading {
 ul {
   font-family: inconsolata; }
 
-button.accordion {
+.light-theme button.accordion {
   background-color: #f1f1f1;
+  border-bottom: 2px solid #ffffff;
+  color: rgba(0, 0, 0, 0.6); }
+  .light-theme button.accordion:hover {
+    background: #bdbdbd; }
+  .light-theme button.accordion.active {
+    background-color: #f1f1f1;
+    color: rgba(0, 0, 0, 0.8); }
+    .light-theme button.accordion.active:hover {
+      color: rgba(0, 0, 0, 0.8); }
+  .light-theme button.accordion:after {
+    color: rgba(0, 0, 0, 0.6); }
+
+.light-theme button.accordion-sub {
+  border-bottom: 1px solid #c9c9c9;
+  color: rgba(0, 0, 0, 0.8); }
+  .light-theme button.accordion-sub:hover {
+    color: rgba(0, 0, 0, 0.8); }
+  .light-theme button.accordion-sub.active {
+    color: rgba(0, 0, 0, 0.8); }
+    .light-theme button.accordion-sub.active:hover {
+      color: rgba(0, 0, 0, 0.8); }
+
+.light-theme .docs-content {
+  color: #000; }
+
+.light-theme .panel.show {
+  color: #000; }
+
+.dark-theme button.accordion {
+  background-color: #3f4045;
+  border-bottom: 2px solid #292a2f;
+  color: #dfdfe0; }
+  .dark-theme button.accordion:hover {
+    background: #3e4d5c; }
+  .dark-theme button.accordion.active {
+    background-color: #3f4045;
+    color: #ededf2; }
+    .dark-theme button.accordion.active:hover {
+      color: #ededf2; }
+  .dark-theme button.accordion:after {
+    color: #dfdfe0; }
+
+.dark-theme button.accordion-sub {
+  border-bottom: 1px solid #252729;
+  color: #ededf2; }
+  .dark-theme button.accordion-sub:hover {
+    color: #ededf2; }
+  .dark-theme button.accordion-sub.active {
+    color: #ededf2; }
+    .dark-theme button.accordion-sub.active:hover {
+      color: #ededf2; }
+
+.dark-theme .docs-content {
+  color: #dfdfe0; }
+
+.dark-theme .panel.show {
+  color: #dfdfe0; }
+
+button.accordion {
   border: none;
-  border-bottom: 2px solid #fff;
-  color: rgba(0, 0, 0, 0.6);
   cursor: pointer;
   font-family: poppins_regular;
   font-size: 16px;
@@ -159,20 +240,14 @@ button.accordion {
   transition: 0.25s ease-in-out;
   width: 100%; }
   button.accordion:hover {
-    background: #bdbdbd;
     border-bottom: 2px solid #00bea4; }
   button.accordion.active {
-    background-color: #f1f1f1;
     border-bottom: 2px solid #00bea4;
-    color: rgba(0, 0, 0, 0.8);
     padding: 8px 14px; }
-    button.accordion.active:hover {
-      color: rgba(0, 0, 0, 0.8); }
     button.accordion.active:after {
       content: "\2796";
       /* Unicode character for "minus" sign (-) */ }
   button.accordion:after {
-    color: rgba(0, 0, 0, 0.6);
     content: '\02795';
     /* Unicode character for "plus" sign (+) */
     float: right;
@@ -181,28 +256,22 @@ button.accordion {
 
 button.accordion-sub {
   background: transparent;
-  border-bottom: 1px solid #c9c9c9;
   border-top: 0;
   border-left: 0;
   border-right: 0;
   border-radius: 0;
-  color: rgba(0, 0, 0, 0.8);
   font-size: 1em;
   font-family: 'poppins_regular';
   padding: .4em .8em .25em;
   text-align: left;
   width: 100%; }
   button.accordion-sub:hover {
-    background: rgba(201, 201, 201, 0.2);
-    color: rgba(0, 0, 0, 0.8); }
+    background: rgba(201, 201, 201, 0.2); }
   button.accordion-sub.active {
     background: transparent;
     border-bottom: 2px solid #1ce8b5;
-    color: rgba(0, 0, 0, 0.8);
     padding-bottom: .2em;
     margin-top: .2em; }
-    button.accordion-sub.active:hover {
-      color: rgba(0, 0, 0, 0.8); }
     button.accordion-sub.active:after {
       content: "\2796";
       /* Unicode character for "minus" sign (-) */
@@ -240,6 +309,22 @@ button.accordion-sub {
   /* Whatever you like, as long as its more than the height of the content (on all screen sizes) */
   opacity: 1; }
 
+.light-theme button,
+.light-theme .button {
+  background-color: #ffffff;
+  color: #000; }
+  .light-theme button.create-project:before,
+  .light-theme .button.create-project:before {
+    color: rgba(0, 0, 0, 0.8); }
+
+.dark-theme button,
+.dark-theme .button {
+  background-color: #292a2f;
+  color: #dfdfe0; }
+  .dark-theme button.create-project:before,
+  .dark-theme .button.create-project:before {
+    color: #ededf2; }
+
 a.button {
   color: black;
   font-size: 11px;
@@ -250,9 +335,7 @@ a.button {
 button,
 .button {
   border: 1px solid #00bea4;
-  background-color: #ffffff;
   border-radius: 3px;
-  color: #000;
   font-size: .8em;
   cursor: pointer;
   font-family: poppins_light;
@@ -279,7 +362,6 @@ button,
       color: #ffffff; }
     button.create-project:before,
     .button.create-project:before {
-      color: rgba(0, 0, 0, 0.8);
       content: '+';
       /* Unicode character for "plus" sign (+) */
       font-family: space_bold;
@@ -339,8 +421,15 @@ input[type="range"].range-slider {
     -webkit-box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
             box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4); }
 
+.light-theme #beaglert-console {
+  background-color: #ffffff;
+  color: #000; }
+
+.dark-theme #beaglert-console {
+  background-color: #292a2f;
+  color: #dfdfe0; }
+
 #beaglert-console {
-  background-color: white;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   font-family: inconsolata, monospace;
@@ -608,14 +697,39 @@ input[type="range"].range-slider {
   margin: 0; }
 
 .subsections .examples-header {
-  color: #009587;
+  color: #950000;
   font-family: space_bold;
   font-size: 1.1em;
   margin: .5em; }
 
+.light-theme button.dropbtn {
+  background-color: #ffffff; }
+
+.light-theme .dropdown-content {
+  background-color: #f9f9f9; }
+  .light-theme .dropdown-content select option {
+    color: #000; }
+  .light-theme .dropdown-content ul > li, .light-theme .dropdown-content ul span, .light-theme .dropdown-content ul a {
+    color: #000; }
+    .light-theme .dropdown-content ul > li:hover, .light-theme .dropdown-content ul span:hover, .light-theme .dropdown-content ul a:hover {
+      background-color: #f1f1f1;
+      color: #000; }
+
+.dark-theme button.dropbtn {
+  background-color: #252729; }
+
+.dark-theme .dropdown-content {
+  background-color: #3f4045; }
+  .dark-theme .dropdown-content select option {
+    color: #dfdfe0; }
+  .dark-theme .dropdown-content ul > li, .dark-theme .dropdown-content ul span, .dark-theme .dropdown-content ul a {
+    color: #dfdfe0; }
+    .dark-theme .dropdown-content ul > li:hover, .dark-theme .dropdown-content ul span:hover, .dark-theme .dropdown-content ul a:hover {
+      background-color: #2c2c2c;
+      color: #ededf2; }
+
 /* Dropdown Button */
 button.dropbtn {
-  background-color: #fff;
   border: 1px solid #00bea4;
   color: #00bea4;
   cursor: pointer;
@@ -677,7 +791,6 @@ select.dropdown-num {
 
 /* Dropdown content (hidden by default) */
 .dropdown-content {
-  background-color: #f9f9f9;
   -webkit-box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
           box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
   display: none;
@@ -695,7 +808,6 @@ select.dropdown-num {
     padding-top: 0;
     width: 200px; }
     .dropdown-content select option {
-      color: black;
       cursor: pointer;
       display: block;
       font-family: poppins_regular;
@@ -724,7 +836,6 @@ select.dropdown-num {
           -ms-user-select: none;
               user-select: none; }
     .dropdown-content ul > li, .dropdown-content ul span, .dropdown-content ul a {
-      color: black;
       cursor: pointer;
       display: block;
       font-family: poppins_regular;
@@ -732,11 +843,14 @@ select.dropdown-num {
       opacity: 1;
       padding: 8px 16px;
       text-decoration: none; }
-      .dropdown-content ul > li:hover, .dropdown-content ul span:hover, .dropdown-content ul a:hover {
-        background-color: #f1f1f1;
-        color: rgba(0, 0, 0, 0.9); }
   .dropdown-content.show {
     display: block; }
+
+.light-theme .mini-dropdown select {
+  color: rgba(0, 0, 0, 0.6); }
+
+.dark-theme .mini-dropdown select {
+  color: #dfdfe0; }
 
 .mini-dropdown select {
   -moz-appearance: none;
@@ -785,8 +899,13 @@ select.dropdown-num {
   .mini-dropdown.disabled:after {
     color: rgba(0, 0, 0, 0.4); }
 
+.light-theme {
+  background: #ffffff; }
+
+.dark-theme {
+  background: #292a2f; }
+
 #editor {
-  background: #fff;
   display: none;
   float: left;
   height: calc(100% - 70px);
@@ -982,6 +1101,12 @@ img.explorer {
   img.explorer:hover {
     background: url("images/icons/explorer_green.svg"); }
 
+.light-theme ul .libraries-list li {
+  color: rgba(0, 0, 0, 0.8); }
+
+.dark-theme ul .libraries-list li {
+  color: #ededf2; }
+
 ul.libraries-list-parent {
   list-style: none;
   margin: 0;
@@ -1044,7 +1169,6 @@ ul.libraries-list-parent {
             margin-block-end: 0;
     margin: .5em 0 0 .5em; }
   ul.libraries-list-parent .libraries-list li {
-    color: rgba(0, 0, 0, 0.8);
     cursor: pointer;
     font-family: inconsolata;
     font-size: 14px;
@@ -1183,6 +1307,18 @@ ul dl {
     fill: rgba(0, 255, 0, 0.6);
     stroke: none; }
 
+.light-theme #popup {
+  background: #ffffff; }
+
+.light-theme button.cancel {
+  background: #ffffff; }
+
+.dark-theme #popup {
+  background: #252729; }
+
+.dark-theme button.cancel {
+  background: #252729; }
+
 #popup-nointeraction {
   display: none;
   height: 100vh;
@@ -1294,7 +1430,6 @@ ul dl {
       #popup button.confirm.button-disabled {
         background: #bdbdbd; }
     #popup button.cancel {
-      background: #ffffff;
       border: 1px solid #bdbdbd; }
       #popup button.cancel:hover {
         background: #e5e5e5;
@@ -1329,9 +1464,30 @@ ul dl {
   border-radius: 10px;
   -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.5); }
 
+.light-theme #tab-menu {
+  background-color: #c9c9c9; }
+
+.light-theme #tab-content-area {
+  background-color: #ffffff; }
+
+.light-theme section#tab-content .title-container {
+  background-color: #ffffff; }
+  .light-theme section#tab-content .title-container h1 {
+    color: rgba(0, 0, 0, 0.8); }
+
+.dark-theme #tab-menu {
+  background-color: #252729; }
+
+.dark-theme #tab-content-area {
+  background-color: #292a2f; }
+
+.dark-theme section#tab-content .title-container {
+  background-color: #292a2f; }
+  .dark-theme section#tab-content .title-container h1 {
+    color: #ededf2; }
+
 /* Tabbed content */
 .tabs {
-  background-color: white;
   height: calc(100% + 35px);
   left: calc(100% - 50px);
   position: absolute;
@@ -1350,13 +1506,11 @@ ul dl {
   left: calc(100% - 438px); }
 
 #tab-menu {
-  background-color: #c9c9c9;
   float: left;
   height: 100%;
   width: 50px; }
 
 #tab-content-area {
-  background-color: #fff;
   height: calc(100% - 76px);
   overflow: auto; }
 
@@ -1367,7 +1521,6 @@ section#tab-content {
   section#tab-content .tab-info {
     display: none; }
   section#tab-content .title-container {
-    background-color: #ffffff;
     height: 75px;
     position: sticky;
     position: -webkit-sticky;
@@ -1380,7 +1533,6 @@ section#tab-content {
       background: transparent; }
     section#tab-content .title-container h1 {
       border-bottom: 10px solid #1ce8b5;
-      color: rgba(0, 0, 0, 0.8);
       display: inline-block;
       font-family: space_bold;
       font-size: 24px;
@@ -1389,8 +1541,41 @@ section#tab-content {
 .disabled {
   display: none; }
 
+.light-theme .choice {
+  color: rgba(0, 0, 0, 0.6); }
+
+.light-theme p.project {
+  color: #000; }
+
+.light-theme .project-actions > .project-text {
+  color: rgba(0, 0, 0, 0.8); }
+
+.light-theme input[type="checkbox"].checkbox-slider::before,
+.light-theme .checkbox-slider input[type="checkbox"]::before {
+  background: #ccc; }
+
+.light-theme textarea {
+  background-color: #ffffff;
+  color: #000; }
+
+.dark-theme .choice {
+  color: #dfdfe0; }
+
+.dark-theme p.project {
+  color: #dfdfe0; }
+
+.dark-theme .project-actions > .project-text {
+  color: #ededf2; }
+
+.dark-theme input[type="checkbox"].checkbox-slider::before,
+.dark-theme .checkbox-slider input[type="checkbox"]::before {
+  background: #5a5a62; }
+
+.dark-theme textarea {
+  background-color: #292a2f;
+  color: #dfdfe0; }
+
 .choice {
-  color: rgba(0, 0, 0, 0.6);
   font-family: poppins_light;
   font-size: 12px;
   padding-bottom: 10px; }
@@ -1461,7 +1646,6 @@ input[type="checkbox"].checkbox-slider,
     position: absolute; }
   input[type="checkbox"].checkbox-slider::before,
   .checkbox-slider input[type="checkbox"]::before {
-    background: #ccc;
     border-radius: 18px;
     height: 18px;
     -webkit-transition: background-color 200ms;
@@ -1530,7 +1714,6 @@ p.project {
   .project-actions > .project-text {
     display: inline;
     font-family: 'inconsolata';
-    color: rgba(0, 0, 0, 0.8);
     font-size: .85em;
     position: absolute;
     top: 0;
@@ -1619,17 +1802,55 @@ p.project {
     .tab-info button.feedback.bug:hover {
       background-color: #ff5e5b; }
 
+.light-theme #tab-menu li#open-tab {
+  background-color: #c9c9c9; }
+
+.light-theme #tab-menu li {
+  background: #c9c9c9; }
+  .light-theme #tab-menu li.explorer.active {
+    background: #ffffff url("../images/icons/folder_active.svg") no-repeat center; }
+  .light-theme #tab-menu li.examples.active {
+    background: #ffffff url("../images/icons/examples_active.svg") no-repeat center; }
+  .light-theme #tab-menu li.settings.active {
+    background: #ffffff url("../images/icons/settings_active.svg") no-repeat center; }
+  .light-theme #tab-menu li.pins.active {
+    background: #ffffff url("../images/icons/pins_active.svg") no-repeat center; }
+  .light-theme #tab-menu li.refs.active {
+    background: #ffffff url("../images/icons/refs_active.svg") no-repeat center; }
+  .light-theme #tab-menu li.libraries.active {
+    background: #ffffff url("../images/icons/library_green.svg") no-repeat center; }
+  .light-theme #tab-menu li.feedback.active {
+    background: #ffffff url("../images/icons/feedback_active.svg") no-repeat center; }
+
+.dark-theme #tab-menu li#open-tab {
+  background-color: #252729; }
+
+.dark-theme #tab-menu li {
+  background: #252729; }
+  .dark-theme #tab-menu li.explorer.active {
+    background: #252729 url("../images/icons/folder_active.svg") no-repeat center; }
+  .dark-theme #tab-menu li.examples.active {
+    background: #252729 url("../images/icons/examples_active.svg") no-repeat center; }
+  .dark-theme #tab-menu li.settings.active {
+    background: #252729 url("../images/icons/settings_active.svg") no-repeat center; }
+  .dark-theme #tab-menu li.pins.active {
+    background: #252729 url("../images/icons/pins_active.svg") no-repeat center; }
+  .dark-theme #tab-menu li.refs.active {
+    background: #252729 url("../images/icons/refs_active.svg") no-repeat center; }
+  .dark-theme #tab-menu li.libraries.active {
+    background: #252729 url("../images/icons/library_green.svg") no-repeat center; }
+  .dark-theme #tab-menu li.feedback.active {
+    background: #252729 url("../images/icons/feedback_active.svg") no-repeat center; }
+
 /*
  * Make each label stack on top of one another.
  *
  */
 #tab-menu li#open-tab {
-  background-color: #c9c9c9;
   max-width: 40px;
   padding-left: 10px; }
 
 #tab-menu li {
-  background: #c9c9c9;
   cursor: pointer;
   height: 50px;
   padding: 0;
@@ -1650,44 +1871,31 @@ p.project {
     background: url("../images/icons/folder_inactive.svg") no-repeat center; }
     #tab-menu li.explorer:hover {
       background: url("../images/icons/folder_active.svg") no-repeat center; }
-    #tab-menu li.explorer.active {
-      background: #ffffff url("../images/icons/folder_active.svg") no-repeat center; }
   #tab-menu li.examples {
     background: url("../images/icons/examples_inactive.svg") no-repeat center; }
     #tab-menu li.examples:hover {
       background: url("../images/icons/examples_active.svg") no-repeat center; }
-    #tab-menu li.examples.active {
-      background: #ffffff url("../images/icons/examples_active.svg") no-repeat center; }
   #tab-menu li.settings {
     background: url("../images/icons/settings_inactive.svg") no-repeat center; }
     #tab-menu li.settings:hover {
       background: url("../images/icons/settings_active.svg") no-repeat center; }
-    #tab-menu li.settings.active {
-      background: #ffffff url("../images/icons/settings_active.svg") no-repeat center; }
   #tab-menu li.pins {
     background: url("../images/icons/pins_inactive.svg") no-repeat center; }
     #tab-menu li.pins:hover {
       background: url("../images/icons/pins_active.svg") no-repeat center; }
-    #tab-menu li.pins.active {
-      background: #ffffff url("../images/icons/pins_active.svg") no-repeat center; }
   #tab-menu li.refs {
     background: url("../images/icons/refs_inactive.svg") no-repeat center; }
     #tab-menu li.refs:hover {
       background: url("../images/icons/refs_active.svg") no-repeat center; }
-    #tab-menu li.refs.active {
-      background: #ffffff url("../images/icons/refs_active.svg") no-repeat center; }
   #tab-menu li.libraries {
     background: url("../images/icons/library_white.svg") no-repeat center; }
     #tab-menu li.libraries:hover {
       background: url("../images/icons/library_green.svg") no-repeat center; }
-    #tab-menu li.libraries.active {
-      background: #ffffff url("../images/icons/library_green.svg") no-repeat center; }
   #tab-menu li.feedback {
     background: url("../images/icons/feedback_inactive.svg") no-repeat center; }
     #tab-menu li.feedback:hover {
       background: url("../images/icons/feedback_active.svg") no-repeat center; }
     #tab-menu li.feedback.active {
-      background: #ffffff url("../images/icons/feedback_active.svg") no-repeat center;
       border-left: 5px solid #ff5e5b; }
   #tab-menu li.active {
     background: #ffffff;
@@ -1718,11 +1926,20 @@ p.project {
 .tab-content-area {
   display: none; }
 
+.light-theme input[type="text"],
+.light-theme input[type="number"] {
+  background: #ffffff;
+  color: #000; }
+
+.dark-theme input[type="text"],
+.dark-theme input[type="number"] {
+  background: #292a2f;
+  color: #ededf2; }
+
 input[type="text"],
 input[type="number"] {
   height: 25px;
-  border: 1px solid #bdbdbd;
-  background: #ffffff; }
+  border: 1px solid #bdbdbd; }
   input[type="text"].number-picker,
   input[type="number"].number-picker {
     border-radius: 0;
@@ -1731,6 +1948,20 @@ input[type="number"] {
   input[type="text"]:disabled,
   input[type="number"]:disabled {
     background: #f1f1f1; }
+
+.light-theme .toolbar {
+  background: #c9c9c9; }
+  .light-theme .toolbar .tool-text {
+    color: #000; }
+  .light-theme .toolbar .system-status-text {
+    color: #000 !important; }
+
+.dark-theme .toolbar {
+  background: #252729; }
+  .dark-theme .toolbar .tool-text {
+    color: #dfdfe0; }
+  .dark-theme .toolbar .system-status-text {
+    color: #dfdfe0 !important; }
 
 @-webkit-keyframes running-button {
   from {
@@ -1757,7 +1988,6 @@ input[type="number"] {
           animation: running-button 2s linear infinite; }
 
 .toolbar {
-  background: #c9c9c9;
   bottom: 0;
   -webkit-box-shadow: 5px 5px #eee;
           box-shadow: 5px 5px #eee;
@@ -1864,6 +2094,14 @@ input[type="number"] {
       margin-top: -14px;
       padding-right: 2.3em; }
 
+.light-theme .file-status .current {
+  color: rgba(0, 0, 0, 0.6);
+  background-color: #e1e1e1; }
+
+.dark-theme .file-status .current {
+  color: #dfdfe0;
+  background-color: #252729; }
+
 .file-status {
   margin-left: 60px;
   white-space: nowrap; }
@@ -1898,7 +2136,6 @@ input[type="number"] {
         display: inline-block; }
   .file-status .current {
     font-family: poppins_regular;
-    color: rgba(0, 0, 0, 0.7);
     padding-right: 20px;
     font-size: 12px; }
 

--- a/IDE/public/css/theme-variables.css
+++ b/IDE/public/css/theme-variables.css
@@ -1,0 +1,62 @@
+:root {
+    --main-background-color: #ffffff;
+    --tabs-color: #c9c9c9;
+    --selected-tab-color: #ffffff;
+    --top-file-status-color: #e1e1e1;
+    --accordion-background-color: #f1f1f1;
+    --hovered-accordion-color: #bdbdbd;
+    --accordion-font-color: rgba(0, 0, 0, 0.6);
+    --accordion-font-color-accent: rgba(0, 0, 0, 0.8);
+    --main-font-color: #000000;
+    --hovered-accordion-color-two: #f9f9f9;
+    --main-font-color-accent: #000000;
+    --cursor-color: #f1f1f1;
+}
+
+/* Light Theme */
+.light-theme {
+    --main-background-color: #ffffff;
+    --tabs-color: #c9c9c9;
+    --selected-tab-color: #ffffff;
+    --top-file-status-color: #e1e1e1;
+    --accordion-background-color: #f1f1f1;
+    --hovered-accordion-color: #bdbdbd;
+    --accordion-font-color: rgba(0, 0, 0, 0.6);
+    --accordion-font-color-accent: rgba(0, 0, 0, 0.8);
+    --main-font-color: #000000;
+    --hovered-accordion-color-two: #f9f9f9;
+    --main-font-color-accent: #000000;
+    --cursor-color: #f1f1f1;
+}
+
+/* Dark Theme */
+.dark-theme {
+    --main-background-color: #292a2f;
+    --tab-color: #252729;
+    --selected-tab-color: #252729;
+    --top-file-status-color: #252729;
+    --accordion-background-color: #3f4045;
+    --hovered-accordion-color: #3e4d5c;
+    --accordion-font-color: #dfdfe0;
+    --accordion-font-color-accent: #ededf2;
+    --main-font-color: #dfdfe0;
+    --hovered-accordion-color-two: #3f4045;
+    --main-font-color-accent: #ededf2;
+    --cursor-color: rgb(44,44,44);
+}
+
+
+/*$theme: (*/
+/*    "white-to-dark-bg-color": map-get($shades, "shade-0"),*/
+/*    "grey-to-dark-toolbar-color": map-get($shades, "shade-1"),*/
+/*    "white-to-dark-toolbar-color": map-get($shades, "shade-2"),*/
+/*    "grey-to-dark-top-bar-color": map-get($shades, "shade-3"),*/
+/*    "grey-light-to-dark-accordion-color": map-get($shades, "shade-4"),*/
+/*    "grey-mid-to-dark-hov-accordion-color": map-get($shades, "shade-5"),*/
+/*    "accordion-font-color": map-get($shades, "shade-6"),*/
+/*    "accordion-highlight-font-color": map-get($shades, "shade-7"),*/
+/*    "black-to-light-text-color": map-get($shades, "shade-8"),*/
+/*    "light-to-dark-dropdown-color": map-get($shades, "shade-9"),*/
+/*    "black-to-highlight-text-color": map-get($shades, "shade-10"),*/
+/*    "cursor-highlight-color": map-get($shades, "shade-11"),*/
+/*  );*/

--- a/IDE/public/index.html
+++ b/IDE/public/index.html
@@ -506,6 +506,13 @@ document.write(generateInputGain(8));
                     </td>
                   </tr>
 
+                  <tr>
+                    <td class="left-choice">Dark Theme:</td>
+                    <td class="right-choice">
+                      <input type="checkbox" id="darkTheme" class="settingsManager checkbox-slider" data-func="setIDESetting" data-key="darkTheme" value="1" >
+                    </td>
+                  </tr>
+
                 </table>
                 <button class="settingsManager settings-button" data-func="restoreDefaultIDESettings">Restore default IDE settings</button>
               </div>

--- a/IDE/public/js/ace/theme-xcode_dark.js
+++ b/IDE/public/js/ace/theme-xcode_dark.js
@@ -1,0 +1,154 @@
+ace.define("ace/theme/xcode_dark",["require","exports","module","ace/lib/dom"], function(require, exports, module) {
+
+exports.isDark = true;
+exports.cssClass = "ace-xcode-dark";
+exports.cssText = "\
+.ace-xcode-dark .ace_gutter {\
+background: #292A2F;\
+color: #8F908A;\
+overflow : hidden;\
+}\
+.ace-xcode-dark .ace_print-margin {\
+width: 1px;\
+background: #292A2F;\
+}\
+.ace-xcode-dark {\
+display: block;\
+overflow-x: auto;\
+padding: .5em;\
+color: #DFDFE0;\
+background-color: #292A2F;\
+}\
+.ace-xcode-dark .ace_invisible {\
+color: #656f81;\
+}\
+.ace-xcode-dark .ace_constant.ace_buildin {\
+color: #EF81B0;\
+}\
+.ace-xcode-dark .ace_constant.ace_language {\
+color: #AB83E4;\
+}\
+.ace-xcode-dark .ace_constant.ace_library {\
+color: #E57668;\
+}\
+.ace-xcode-dark .ace_invalid {\
+color: #F8F8F0;\
+background-color: #F92672;\
+}\
+.ace-xcode-dark .ace_fold {\
+background-color: #A6E22E;\
+border-color: #F8F8F2;\
+}\
+.ace-xcode-dark .ace_support.ace_function {\
+color: #4EB0CC;\
+}\
+.ace-xcode-dark .ace_support.ace_constant {\
+color: #4EB0CC;\
+}\
+.ace-xcode-dark .ace_support.ace_other,\
+.ace-xcode-dark .ace_storage.ace_type,\
+.ace-xcode-dark .ace_support.ace_class,\
+.ace-xcode-dark .ace_support.ace_type {\
+font-style: italic;\
+color: #66D9EF;\
+}\
+.ace-xcode-dark .ace_variable.ace_parameter {\
+font-style:italic;\
+color: #FD971F;\
+}\
+.ace-xcode-dark .ace_keyword.ace_operator {\
+color: #DFDFE0;\
+}\
+.ace-xcode-dark .ace_comment {\
+color: #A5B0BD;\
+}\
+.ace-xcode-dark .ace_comment.ace_doc {\
+color: #75715E;\
+}\
+.ace-xcode-dark .ace_comment.ace_doc.ace_tag {\
+color: #EF81B0;\
+}\
+.ace-xcode-dark .ace_constant.ace_numeric {\
+color: #D5CA86;\
+}\
+.ace-xcode-dark .ace_variable {\
+color: #BBF0E4;\
+}\
+.ace-xcode-dark .ace_xml-pe {\
+color: rgb(104, 104, 91);\
+}\
+.ace-xcode-dark .ace_entity.ace_name.ace_function {\
+color: #4Eb0CC;\
+}\
+.ace-xcode-dark .ace_heading {\
+color: #DFDFE0;\
+}\
+.ace-xcode-dark .ace_list {\
+color: #4EB0CC;\
+}\
+.ace-xcode-dark .ace_marker-layer .ace_selection {\
+background: #49483E;\
+}\
+.ace-xcode-dark .ace_marker-layer .ace_step {\
+background: rgb(102, 82, 0);\
+}\
+.ace-xcode-dark .ace_marker-layer .ace_stack {\
+background: rgb(164, 229, 101);\
+}\
+.ace-xcode-dark .ace_marker-layer .ace_bracket {\
+margin: -1px 0 0 -1px;\
+border: 1px solid #828C97;\
+}\
+.ace-xcode-dark .ace_marker-layer .ace_active-line {\
+background: #202020;\
+}\
+.ace-xcode-dark .ace_gutter-active-line {\
+background-color: #2F113239;\
+}\
+.ace-xcode-dark .ace_marker-layer .ace_selected-word {\
+border: 1px solid #656F81;\
+}\
+.ace-xcode-dark .ace_storage,\
+.ace-xcode-dark .ace_keyword,\
+.ace-xcode-dark .ace_meta.ace_tag {\
+color: #EF81B0;\
+}\
+.ace-xcode-dark .ace_string.ace_regex {\
+color: #F08875;\
+}\
+.ace-xcode-dark .ace_string {\
+color: #F08875;\
+}\
+.ace-xcode-dark .ace_entity.ace_other.ace_attribute-name {\
+color: #F08875;\
+}\
+.ace-xcode-dark .ace_indent-guide {\
+background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAEklEQVQImWPQ0FD0ZXBzd/wPAAjVAoxeSgNeAAAAAElFTkSuQmCC) right repeat-y;\
+}\
+.ace-xcode-dark .ace_entity.ace_other{\
+color: #DFDFE0;\
+}\
+.ace-xcode-dark.ace_multiselect .ace_selection.ace_start {\
+box-shadow: 0 0 3px 0px #646F83;\
+}\
+.ace-content{\
+  border-top:1px solid #43464a;\
+}\
+";
+
+var dom = require("../lib/dom");
+dom.importCssString(exports.cssText, exports.cssClass);
+});                (function() {
+                    ace.require(["ace/theme/xcode_dark"], function(m) {
+                        if (typeof module == "object" && typeof exports == "object" && module) {
+                            module.exports = m;
+                        }
+                    });
+                })();
+
+
+
+
+
+
+

--- a/IDE/public/js/ace/theme-xcode_dark.js
+++ b/IDE/public/js/ace/theme-xcode_dark.js
@@ -15,7 +15,6 @@ background: #292A2F;\
 .ace-xcode-dark {\
 display: block;\
 overflow-x: auto;\
-padding: .5em;\
 color: #DFDFE0;\
 background-color: #292A2F;\
 }\

--- a/IDE/public/js/bundle.js
+++ b/IDE/public/js/bundle.js
@@ -2185,7 +2185,8 @@ var EditorView = function (_View) {
 		key: '_darkTheme',
 		value: function _darkTheme(value) {
 			if (parseInt(value)) {
-				this.editor.setTheme("ace/theme/xcode_dark");
+				// this.editor.setTheme("ace/theme/xcode_dark");
+				this.editor.setTheme("ace/theme/monokai");
 			} else {
 				this.editor.setTheme("ace/theme/chrome");
 			}
@@ -4595,6 +4596,20 @@ var SettingsView = function (_View) {
 				}
 			});
 		}
+	// }, {
+	// 	key: '_darkTheme',
+	// 	value: function _darkTheme(func, key, value) {
+	// 		console.log("in _darkTheme")
+	// 		var app = document.querySelector(".app");
+	// 		// editor theme has changed
+	// 		if (parseInt(func)) {
+	// 			app.classList.remove('light');
+	// 			app.classList.add('dark');
+	// 		} else {
+	// 			app.classList.remove('dark');
+	// 			app.classList.add('light');
+    //   		}
+    // 	}
 	}, {
 		key: '_boardString',
 		value: function _boardString(data) {

--- a/IDE/public/js/bundle.js
+++ b/IDE/public/js/bundle.js
@@ -2179,25 +2179,6 @@ var EditorView = function (_View) {
 				this.__focus(opts.focus);
 			}
 		}
-		// editor theme has changed
-
-	}, {
-		key: '_darkTheme',
-		value: function _darkTheme(value) {
-			var isDarkTheme = parseInt(value)
-			var body = $('body');
-
-			if (isDarkTheme) {
-				this.editor.setTheme("ace/theme/xcode_dark");
-				// this.editor.setTheme("ace/theme/monokai");
-				body.toggleClass('light-theme', Boolean(false));
-				body.toggleClass('dark-theme', Boolean(true));
-			} else {
-				this.editor.setTheme("ace/theme/chrome");
-				body.toggleClass('dark-theme', Boolean(false));
-				body.toggleClass('light-theme', Boolean(true));
-			}
-		}
 		// editor focus has changed
 
 	}, {
@@ -2268,6 +2249,24 @@ var EditorView = function (_View) {
 		key: '_fileName',
 		value: function _fileName(name, data) {
 			currentFile = name;
+		}
+
+		// switch between light and dark theme
+
+	}, {
+		key: '_darkTheme',
+		value: function _darkTheme(isDarkTheme) {
+			var body = $('body');
+			if (isDarkTheme) {
+				this.editor.setTheme("ace/theme/xcode_dark");
+				// this.editor.setTheme("ace/theme/monokai");
+				body.toggleClass('light-theme', Boolean(false));
+				body.toggleClass('dark-theme', Boolean(true));
+			} else {
+				this.editor.setTheme("ace/theme/chrome");
+				body.toggleClass('dark-theme', Boolean(false));
+				body.toggleClass('light-theme', Boolean(true));
+			}
 		}
 	}, {
 		key: 'getCurrentWord',

--- a/IDE/public/js/bundle.js
+++ b/IDE/public/js/bundle.js
@@ -417,7 +417,7 @@ settingsView.on('project-settings', function (data) {
 
 settingsView.on('IDE-settings', function (data) {
 	data.currentProject = models.project.getKey('currentProject');
-	// console.log('IDE-settings', data);
+	//console.log('IDE-settings', data);
 	socket.emit('IDE-settings', data);
 });
 settingsView.on('run-on-boot', function (project) {
@@ -2184,16 +2184,23 @@ var EditorView = function (_View) {
 	}, {
 		key: '_darkTheme',
 		value: function _darkTheme(value) {
-			if (parseInt(value)) {
-				// this.editor.setTheme("ace/theme/xcode_dark");
-				this.editor.setTheme("ace/theme/monokai");
+			var isDarkTheme = parseInt(value)
+			var body = $('body');
+
+			if (isDarkTheme) {
+				this.editor.setTheme("ace/theme/xcode_dark");
+				// this.editor.setTheme("ace/theme/monokai");
+				body.toggleClass('light-theme', Boolean(false));
+				body.toggleClass('dark-theme', Boolean(true));
 			} else {
 				this.editor.setTheme("ace/theme/chrome");
+				body.toggleClass('dark-theme', Boolean(false));
+				body.toggleClass('light-theme', Boolean(true));
 			}
 		}
 		// editor focus has changed
 
-  	}, {
+	}, {
 		key: '__focus',
 		value: function __focus(data) {
 
@@ -4596,20 +4603,6 @@ var SettingsView = function (_View) {
 				}
 			});
 		}
-	// }, {
-	// 	key: '_darkTheme',
-	// 	value: function _darkTheme(func, key, value) {
-	// 		console.log("in _darkTheme")
-	// 		var app = document.querySelector(".app");
-	// 		// editor theme has changed
-	// 		if (parseInt(func)) {
-	// 			app.classList.remove('light');
-	// 			app.classList.add('dark');
-	// 		} else {
-	// 			app.classList.remove('dark');
-	// 			app.classList.add('light');
-    //   		}
-    // 	}
 	}, {
 		key: '_boardString',
 		value: function _boardString(data) {

--- a/IDE/public/js/bundle.js
+++ b/IDE/public/js/bundle.js
@@ -417,7 +417,7 @@ settingsView.on('project-settings', function (data) {
 
 settingsView.on('IDE-settings', function (data) {
 	data.currentProject = models.project.getKey('currentProject');
-	//console.log('IDE-settings', data);
+	// console.log('IDE-settings', data);
 	socket.emit('IDE-settings', data);
 });
 settingsView.on('run-on-boot', function (project) {
@@ -2179,9 +2179,20 @@ var EditorView = function (_View) {
 				this.__focus(opts.focus);
 			}
 		}
-		// editor focus has changed
+		// editor theme has changed
 
 	}, {
+		key: '_darkTheme',
+		value: function _darkTheme(value) {
+			if (parseInt(value)) {
+				this.editor.setTheme("ace/theme/xcode_dark");
+			} else {
+				this.editor.setTheme("ace/theme/chrome");
+			}
+		}
+		// editor focus has changed
+
+  	}, {
 		key: '__focus',
 		value: function __focus(data) {
 

--- a/IDE/src/IDESettings.ts
+++ b/IDE/src/IDESettings.ts
@@ -71,6 +71,7 @@ function default_IDE_settings(){
 		'cpuMonitoring'		: 1,
 		'cpuMonitoringVerbose'	: 0,
 		'consoleDelete'		: 0,
-		'viewHiddenFiles'	: 0
+		'viewHiddenFiles'	: 0,
+		'darkTheme'			: 0
 	};
 }


### PR DESCRIPTION
Hey! :) Here's my second attempt at implementing a theme switching for Bela's IDE. 

The approach here is to use SCSS `@mixin` and a map, allowing to define a colour variables for each of the themes. 

The main logic and colour variable definitions are located in `IDE/frontend-dev/scss/base.scss`.

The idea is that we (only) move every specific element properties affected by the theme switching into a theme switching function (`themify`), performing the colour switch only on the relevant properties. 

In each scss file containing elements which need to change colour, the relevant properties for the element is being moved at the top of the file inside of the themify function.

While this may not the cleanest of look, it allows 2 things:

1. To only transpile into css the relevant properties, rather than having an entire duplicate of the code for each added theme.
2. It gives a good base to support further themes. We only need to define the colour palettes and the rest of the infrastructure is already there.

There's still a bit of work to get this polished, but sharing now if people wants to start testing/using it before.

ps: You can discard the commit history before **Feb 14, 2024**. They shouldn't be in the commit history but not sure how to safely rewrite the history.